### PR TITLE
Separate out path profiling and interpolation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lasy"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 description = "A small library dedicated to LASER path optimisation."
 readme = "README.md"


### PR DESCRIPTION
This separates the path profiling and inteprolation steps into their own
functions. This allows for applying the profiling and interpolation
steps to non-euler-circuit paths. The euler circuit path interpolation
implementation has been refactored in terms of these new functions.